### PR TITLE
Fix package description

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
- Platform iOS v15 is unavailable in PackageDescrption 5.3, 'v15' was introduced in PackageDescription 5.5

<!-- We don’t accept pull requests at the moment. Please reach out to our support team at support@batch.com or via the Live-Chat, or open an issue. -->
